### PR TITLE
Add unit tests for API and system utilities

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,79 @@
+import os
+import sys
+import unittest
+from unittest.mock import patch
+
+# Ensure package and its modules can be imported when they use absolute imports
+CURRENT_DIR = os.path.dirname(__file__)
+PROJECT_ROOT = os.path.abspath(os.path.join(CURRENT_DIR, '..'))
+PACKAGE_DIR = os.path.join(PROJECT_ROOT, 'windows_ubuntu_switcher')
+sys.path.insert(0, PROJECT_ROOT)
+sys.path.insert(0, PACKAGE_DIR)
+
+from windows_ubuntu_switcher.api import WindowsUbuntuSwitcherAPI, parse_args
+
+
+class TestWindowsUbuntuSwitcherAPI(unittest.TestCase):
+    def test_get_status_success(self):
+        mock_status = {'system': 'TestOS', 's_drive_accessible': True}
+        with patch('windows_ubuntu_switcher.api.check_system_status', return_value=mock_status):
+            result = WindowsUbuntuSwitcherAPI.get_status()
+        self.assertTrue(result['success'])
+        self.assertEqual(result['status'], mock_status)
+
+    @patch('windows_ubuntu_switcher.api.reboot_system')
+    @patch('windows_ubuntu_switcher.api.create_flag_file')
+    def test_switch_to_ubuntu_non_silent_success(self, mock_create, mock_reboot):
+        mock_create.return_value = True
+        api = WindowsUbuntuSwitcherAPI()
+        result = api.switch_to_ubuntu(silent=False)
+        self.assertTrue(result['success'])
+        self.assertIn('标志文件创建成功', result['message'])
+        mock_reboot.assert_not_called()
+
+    @patch('windows_ubuntu_switcher.api.reboot_system')
+    @patch('windows_ubuntu_switcher.api.create_flag_file')
+    def test_switch_to_ubuntu_silent_success(self, mock_create, mock_reboot):
+        mock_create.return_value = True
+        mock_reboot.return_value = True
+        api = WindowsUbuntuSwitcherAPI()
+        result = api.switch_to_ubuntu(silent=True)
+        self.assertTrue(result['success'])
+        self.assertIn('系统重启中', result['message'])
+        mock_reboot.assert_called_once()
+
+    @patch('windows_ubuntu_switcher.api.reboot_system')
+    @patch('windows_ubuntu_switcher.api.create_flag_file')
+    def test_switch_to_ubuntu_silent_reboot_fail(self, mock_create, mock_reboot):
+        mock_create.return_value = True
+        mock_reboot.return_value = False
+        api = WindowsUbuntuSwitcherAPI()
+        result = api.switch_to_ubuntu(silent=True)
+        self.assertFalse(result['success'])
+        self.assertEqual(result['error'], '系统重启失败')
+
+    @patch('windows_ubuntu_switcher.api.create_flag_file', return_value=False)
+    def test_switch_to_ubuntu_create_flag_fail(self, mock_create):
+        api = WindowsUbuntuSwitcherAPI()
+        result = api.switch_to_ubuntu(silent=False)
+        self.assertFalse(result['success'])
+        self.assertEqual(result['error'], '标志文件创建失败')
+
+
+class TestParseArgs(unittest.TestCase):
+    def test_parse_args_status(self):
+        with patch('windows_ubuntu_switcher.api.sys.argv', ['prog', '--status']):
+            args = parse_args()
+        self.assertTrue(args.status)
+        self.assertFalse(args.switch)
+
+    def test_parse_args_switch_silent_json(self):
+        with patch('windows_ubuntu_switcher.api.sys.argv', ['prog', '--switch', '--silent', '--json']):
+            args = parse_args()
+        self.assertTrue(args.switch)
+        self.assertTrue(args.silent)
+        self.assertTrue(args.json)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_system_utils.py
+++ b/tests/test_system_utils.py
@@ -1,0 +1,35 @@
+import os
+import sys
+import unittest
+from unittest.mock import patch
+
+# Ensure modules can be imported when absolute imports are used internally
+CURRENT_DIR = os.path.dirname(__file__)
+PROJECT_ROOT = os.path.abspath(os.path.join(CURRENT_DIR, '..'))
+PACKAGE_DIR = os.path.join(PROJECT_ROOT, 'windows_ubuntu_switcher')
+sys.path.insert(0, PROJECT_ROOT)
+sys.path.insert(0, PACKAGE_DIR)
+
+from windows_ubuntu_switcher.system_utils import create_flag_file, check_system_status
+
+
+class TestSystemUtils(unittest.TestCase):
+    @patch('windows_ubuntu_switcher.system_utils.time.sleep', return_value=None)
+    @patch('windows_ubuntu_switcher.system_utils.messagebox.showerror')
+    @patch('windows_ubuntu_switcher.system_utils.os.path.exists', return_value=False)
+    def test_create_flag_file_s_drive_missing(self, mock_exists, mock_msgbox, mock_sleep):
+        result = create_flag_file()
+        self.assertFalse(result)
+        mock_msgbox.assert_called_once()
+
+    def test_check_system_status(self):
+        with patch('windows_ubuntu_switcher.system_utils.os.path.exists', return_value=True), \
+             patch('platform.system', return_value='TestOS'), \
+             patch('platform.version', return_value='1.0'):
+            status = check_system_status()
+        self.assertEqual(status['system'], 'TestOS 1.0')
+        self.assertTrue(status['s_drive_accessible'])
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- add tests for WindowsUbuntuSwitcherAPI covering status retrieval, reboot scenarios, and CLI argument parsing
- test system utilities for missing shared drive and status reporting

## Testing
- `pip install -r requirements.txt`
- `python -m unittest`


------
https://chatgpt.com/codex/tasks/task_e_68a7595523c8832a8abd65a6b4d0584f